### PR TITLE
init: Set permissions for dynamic partial update node

### DIFF
--- a/init/init_msm.c
+++ b/init/init_msm.c
@@ -208,6 +208,10 @@ void set_display_node_perms()
     snprintf(tmp, sizeof(tmp), "%sfb0/dynamic_fps", sys_fb_path);
     setPerms(tmp, 0664);
     setOwners(tmp, AID_SYSTEM, AID_GRAPHICS);
+    // Set permissions for dynamic partial update
+    snprintf(tmp, sizeof(tmp), "%sfb0/dyn_pu", sys_fb_path);
+    setPerms(tmp, 0664);
+    setOwners(tmp, AID_SYSTEM, AID_GRAPHICS);
 }
 
 static int check_rlim_action()


### PR DESCRIPTION
Set file permissions for dynamic partial update system node to
control the feature at runtime.

Change-Id: Icd4799907d168c2606c8811c73f4fedd847d55f0